### PR TITLE
Fix stray tokens in search service

### DIFF
--- a/src/lib/services/search.ts
+++ b/src/lib/services/search.ts
@@ -75,7 +75,6 @@ export async function searchCompanies(keyword: string): Promise<any[]> {
     }
 
     const tokenData = await tokenResponse.json();
-    });
 
     try {
       // Search INSEE data
@@ -124,11 +123,6 @@ export async function searchCompanies(keyword: string): Promise<any[]> {
 
       
       const inseeResponse = await fetch(url, requestOptions);
-
-        status: inseeResponse.status,
-        statusText: inseeResponse.statusText,
-        headers: Object.fromEntries(inseeResponse.headers)
-      });
 
       // Handle 404 as a valid "no results" response
       if (inseeResponse.status === 404) {


### PR DESCRIPTION
## Summary
- clean up search service by removing leftover `});`
- drop obsolete request logging lines

## Testing
- `npm run build` *(fails: next not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6850135a858083228b8c29cf6a787427