### PR TITLE
Fix MongoDB URI config

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ pnpm dev
 bun dev
 ```
 
+## Environment Variables
+
+The application expects a MongoDB connection string in the `MONGODB_URI` environment variable. Create a `.env.local` file and define your connection string:
+
+```bash
+MONGODB_URI=your_connection_string
+```
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/src/lib/db/mongodb.ts
+++ b/src/lib/db/mongodb.ts
@@ -1,11 +1,9 @@
 import mongoose from 'mongoose';
 
-const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://dev_socitie_usr:12345678socitie123@10.8.0.52:27017/dev_socitie?authSource=dev_socitie';
+const MONGODB_URI = process.env.MONGODB_URI;
 
 if (!MONGODB_URI) {
-  throw new Error(
-    'Please define the MONGODB_URI environment variable inside .env.local'
-  );
+  throw new Error('Please define the MONGODB_URI environment variable');
 }
 
 declare global {


### PR DESCRIPTION
## Summary
- remove default DB connection string
- fail fast when `MONGODB_URI` isn't provided
- document required `MONGODB_URI` variable

## Testing
- `npm run lint --silent` *(fails: `next` not found)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68506884fbb8832285ad025712b416bf