### PR TITLE
Store registre token outside public directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 
 # production
 /build
+/tmp
 
 # misc
 .DS_Store

--- a/src/utils/registre-api.ts
+++ b/src/utils/registre-api.ts
@@ -4,7 +4,15 @@ import path from 'path';
 async function getRegistreToken() {
     const username = process.env.regent_login;
     const password = process.env.regent_password;
-    const tokenPath = path.join(process.cwd(), 'public', 'regentreprises.txt');
+    const tokenDir = path.join(process.cwd(), 'tmp');
+    const tokenPath = path.join(tokenDir, 'regentreprises.txt');
+
+    try {
+        fs.mkdirSync(tokenDir, { recursive: true });
+    } catch (err) {
+        console.error('Error ensuring token directory exists:', err);
+        throw err;
+    }
 
     try {
         // Check if token file exists and is not expired (30 minutes)

--- a/src/utils/registre-token.ts
+++ b/src/utils/registre-token.ts
@@ -1,10 +1,18 @@
 import fs from 'fs';
 import path from 'path';
 
-const TOKEN_FILE = path.join(process.cwd(), 'public', 'regentreprises.txt');
+const TOKEN_DIR = path.join(process.cwd(), 'tmp');
+const TOKEN_FILE = path.join(TOKEN_DIR, 'regentreprises.txt');
 
 export async function getRegistreToken() {
   try {
+    try {
+      fs.mkdirSync(TOKEN_DIR, { recursive: true });
+    } catch (err) {
+      console.error('Error ensuring token directory exists:', err);
+      throw err;
+    }
+
     // Check if token file exists and is not expired (30 minutes)
     if (fs.existsSync(TOKEN_FILE)) {
       const stats = fs.statSync(TOKEN_FILE);


### PR DESCRIPTION
## Summary
- store registre token in `tmp/` folder instead of `public/`
- create token directory with error handling
- ignore `tmp/` directory in git

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850df4d3ccc8322aea238a9c25b8007