### PR TITLE
Enhance CSP by adding nonces

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 import { Header } from "@/components/layout/header";
 import { Footer as LayoutFooter } from "@/components/layout/footer";
 import { JsonLd } from "@/components/json-ld";
+import { headers } from "next/headers";
 import "./globals.css";
 
 const inter = Inter({
@@ -99,6 +100,7 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const nonce = headers().get('x-nonce') || undefined;
   return (
     <html lang="fr" dir="ltr">
       <head>
@@ -112,12 +114,13 @@ export default function RootLayout({
           rel="stylesheet"
           href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
         />
-        <JsonLd />
+        <JsonLd nonce={nonce} />
         <link rel="alternate" type="application/rss+xml" title="RSS Feed" href="/feed.xml" />
         {/* Preconnect to external domains */}
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <script
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html: `
               if ('serviceWorker' in navigator) {

--- a/src/components/json-ld.tsx
+++ b/src/components/json-ld.tsx
@@ -4,9 +4,10 @@ interface JsonLdProps {
   organizationData?: any;
   breadcrumbData?: any;
   localBusinessData?: any;
+  nonce?: string;
 }
 
-export function JsonLd({ organizationData, breadcrumbData, localBusinessData }: JsonLdProps) {
+export function JsonLd({ organizationData, breadcrumbData, localBusinessData, nonce }: JsonLdProps) {
   const baseOrganizationData = {
     "@context": "https://schema.org",
     "@type": "Organization",
@@ -73,6 +74,7 @@ export function JsonLd({ organizationData, breadcrumbData, localBusinessData }: 
   return (
     <>
       <script
+        nonce={nonce}
         type="application/ld+json"
         dangerouslySetInnerHTML={{
           __html: JSON.stringify(organizationData || baseOrganizationData)
@@ -80,6 +82,7 @@ export function JsonLd({ organizationData, breadcrumbData, localBusinessData }: 
       />
       {breadcrumbData && (
         <script
+          nonce={nonce}
           type="application/ld+json"
           dangerouslySetInnerHTML={{
             __html: JSON.stringify(breadcrumbData)
@@ -88,6 +91,7 @@ export function JsonLd({ organizationData, breadcrumbData, localBusinessData }: 
       )}
       {localBusinessData && (
         <script
+          nonce={nonce}
           type="application/ld+json"
           dangerouslySetInnerHTML={{
             __html: JSON.stringify(localBusinessData || baseLocalBusinessData)

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { randomBytes } from 'crypto';
 
 export function middleware(request: NextRequest) {
   // Don't apply CSP to service worker
@@ -7,16 +8,17 @@ export function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
+  const nonce = randomBytes(16).toString('base64');
   const response = NextResponse.next();
   const headers = response.headers;
+  headers.set('X-Nonce', nonce);
 
   // Content Security Policy
   headers.set(
     'Content-Security-Policy',
     [
       "default-src 'self'",
-      // Allow inline scripts and eval for development
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com blob: https://api.mapbox.com",
+      `script-src 'self' 'nonce-${nonce}' https://cdnjs.cloudflare.com blob: https://api.mapbox.com`,
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.mapbox.com",
       "img-src 'self' data: https: blob: https://*.mapbox.com https://api.mapbox.com",
       "font-src 'self' https://fonts.gstatic.com",


### PR DESCRIPTION
## Summary
- generate a per-request nonce in middleware
- include nonce in Content Security Policy
- use nonce in layout and JSON-LD scripts

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850df5a4ad8832291619bdc194dfdb2