### PR TITLE
Fix prop type for company details page

### DIFF
--- a/src/app/[companyName]/[siren]/page.tsx
+++ b/src/app/[companyName]/[siren]/page.tsx
@@ -1,9 +1,9 @@
 // @ts-nocheck
-import { Metadata } from 'next';
+import { Metadata, type PageProps } from 'next';
 import { CompanyData } from '@/types/company';
 import CompanyDetailsClient from '@/components/CompanyDetailsClient';
 
-interface CompanyDetailsProps {
+interface CompanyDetailsProps extends PageProps {
   params: {
     siren: string;
     companyName: string;


### PR DESCRIPTION
## Summary
- extend `CompanyDetailsProps` from Next.js `PageProps`

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850677a603483228b07ec403e09e7b5